### PR TITLE
Add support new gametags

### DIFF
--- a/src/Static/IServerInfoUpdate.cs
+++ b/src/Static/IServerInfoUpdate.cs
@@ -37,7 +37,7 @@ public partial class Category_Static
 
 				try
 				{
-					ServerTagEx.SetRequiredTag("carbon");
+					ServerTagEx.SetRequiredTag("^y");
 
 					if (Community.Runtime.ClientConfig.Enabled)
 					{
@@ -50,11 +50,11 @@ public partial class Category_Static
 
 					if (Community.Runtime.Config.IsModded || ForceModded)
 					{
-						ServerTagEx.SetRequiredTag("modded");
+						ServerTagEx.SetRequiredTag("^z");
 					}
 					else
 					{
-						ServerTagEx.UnsetRequiredTag("modded");
+						ServerTagEx.UnsetRequiredTag("^z");
 					}
 				}
 				catch (Exception ex)


### PR DESCRIPTION
In the upcoming Rust update changed game tags.

Class **ServerTagCompressor**
```cs
	// Token: 0x0400002F RID: 47
	private static readonly IReadOnlyDictionary<char, string> charToTag = new Dictionary<char, string>
	{
		{ 'b', "biweekly" },
		{ 'c', "creative" },
		{ 'd', "training" },
		{ 'e', "minigame" },
		{ 'g', "gamemode" },
		{ 'h', "hardcore" },
		{ 'i', "battlefield" },
		{ 'j', "broyale" },
		{ 'k', "builds" },
		{ 'm', "monthly" },
		{ 'o', "oxide" },
		{ 'p', "pve" },
		{ 'r', "roleplay" },
		{ 's', "softcore" },
		{ 't', "tut" },
		{ 'v', "vanilla" },
		{ 'w', "weekly" },
		{ 'y', "carbon" },
		{ 'z', "modded" }
	};

	// Token: 0x04000031 RID: 49
	public static readonly char TagPrefixCharacter = '^';
