### PR TITLE
Fix polluting main console with carbon commands replies from another rcon connection

### DIFF
--- a/src/Static/IOnRconCommand.cs
+++ b/src/Static/IOnRconCommand.cs
@@ -65,8 +65,7 @@ public partial class Category_Static
 					}
 
 					var consoleArg = FormatterServices.GetUninitializedObject(typeof(Arg)) as Arg;
-					var option = Option.Server;
-					option.FromRcon = true;
+					var option = Option.Server.Quiet().FromRconConnection(cmd.ConnectionId, cmd.Ip.ToString(), cmd.Name);
 					consoleArg.Option = option;
 					consoleArg.FullString = cmd.Message;
 					consoleArg.Args = arguments;


### PR DESCRIPTION
- Depends on https://github.com/CarbonCommunity/Carbon.Bootstrap/pull/2
- Not very tested, but should hopefully work

### That is how FP handles rcon commands currently

<img width="1433" height="626" alt="25-11-18_16-17-13" src="https://github.com/user-attachments/assets/b80d1d0f-2963-45bd-b985-6eecdea07837" />
